### PR TITLE
auto

### DIFF
--- a/core/pipeline/translator.go
+++ b/core/pipeline/translator.go
@@ -90,6 +90,9 @@ func parsePartitionInfo(partitions []protocol.Partition, produceQueue chan<- str
 		endOffset := strconv.Itoa(partition.End.Offset)
 		// endOffsetTimestamp := strconv.FormatInt(partition.End.Timestamp, 10)
 		owner := partition.Owner
+		if owner == "" {
+			owner = "null"
+		}
 
 		topicTag := "topic=" + topic
 		partitionTag := "partition=" + partitionID
@@ -116,6 +119,9 @@ func parseMaxLagInfo(maxLag protocol.MaxLag, produceQueue chan<- string, prefix 
 	// metrics: partitionID, currentLag, startOffset, endOffset, topic
 
 	owner := maxLag.Owner
+	if owner == "" {
+		owner = "null"
+	}
 	ownerTag := "owner=" + owner
 
 	// MaxLagPartition Level handle


### PR DESCRIPTION
Sometimes the owner of one consumer-topic can be null. Set it to "null" so that wavefront can handle the metric. Skip this info.
```
{"error":false,"message":"consumer detail returned","topics":{"DataConnectSfdcBulkJob":[{"offsets":[null,null,null,null,null,null,null,null,null,null],"owner":"","current-lag":0},{"offsets":[null,null,null,null,null,null,null,null,null,null],"owner":"","current-lag":0},{"offsets":[null,null,null,null,null,null,null,null,null,null],"owner":"","current-lag":0},{"offsets":[null,null,null,null,null,null,null,null,null,null],"owner":"","current-lag":0},{"offsets":[null,null,null,null,null,null,null,null,null,{"offset":1,"timestamp":1549060461184,"lag":0}],"owner":"","current-lag":0},{"offsets":[null,null,null,null,null,null,null,{"offset":1,"timestamp":1549057697791,"lag":0},{"offset":2,"timestamp":1549064233905,"lag":0},{"offset":3,"timestamp":1549310503728,"lag":0}],"owner":"","current-lag":0},{"offsets":[null,null,null,null,null,null,null,null,null,{"offset":1,"timestamp":1549310119371,"lag":0}],"owner":"","current-lag":0},{"offsets":[null,null,null,null,null,null,null,null,null,null],"owner":"","current-lag":0}]},"request":{"url":"/v3/kafka/staging2/consumer/sfdc-bulk-job","host":"24151b0ff8c7"}}
```
