### PR TITLE
generalize syncMap to support more structure and logic

### DIFF
--- a/core/pipeline/aliveConsumersMaintainer.go
+++ b/core/pipeline/aliveConsumersMaintainer.go
@@ -39,7 +39,7 @@ func AliveConsumersMaintainer(link string, produceQueue chan string, rcsTotal *u
 		}
 		for _, cluster := range clusters.([]interface{}) {
 			clusterString := cluster.(string)
-			consumersSet := clusterConsumerMap.GetChild(clusterString)
+			consumersSet := clusterConsumerMap.GetChild(clusterString, make(map[string]interface{})).(map[string]interface{})
 
 			clusterConsumerMap.SetLock(clusterString)
 
@@ -90,7 +90,10 @@ func NewConsumerForLag(consumersLink string, consumer string, cluster string, sn
 		lagStatusQueue <- lagStatus
 	}
 
-	snm.DeregisterChild(cluster, consumer)
+	// snm.DeregisterChild(cluster, consumer)
+	snm.SetLock(cluster)
+	delete(snm.GetChild(cluster, nil).(map[string]interface{}), consumer)
+	snm.ReleaseLock(cluster)
 
 	close(lagStatusQueue)
 	log.Fatalf("Consumer is invalid: %s\tcluster:%s\n", consumer, cluster)

--- a/core/pipeline/aliveTopicsMaintainer.go
+++ b/core/pipeline/aliveTopicsMaintainer.go
@@ -29,7 +29,7 @@ func AliveTopicsMaintainer(link string, produceQueue chan string) {
 		}
 		for _, cluster := range clusters.([]interface{}) {
 			clusterString := cluster.(string)
-			topicsSet := clusterTopicMap.GetChild(clusterString)
+			topicsSet := clusterTopicMap.GetChild(clusterString, make(map[string]interface{})).(map[string]interface{})
 
 			clusterTopicMap.SetLock(clusterString)
 
@@ -70,7 +70,11 @@ func newTopic(topicLink string, topic string, cluster string, produceQueue chan 
 		topicOffsetHandler(topicOffset, prefix, postfix+" topic="+topic, produceQueue)
 	}
 
-	snm.DeregisterChild(cluster, topic)
+	// snm.DeregisterChild(cluster, topic)
+	snm.SetLock(cluster)
+	delete(snm.GetChild(cluster, nil).(map[string]interface{}), topic)
+	snm.ReleaseLock(cluster)
+
 	log.Fatalf("Topic is invalid: %s\tcluster:%s\n", topic, cluster)
 }
 

--- a/core/pipeline/translator.go
+++ b/core/pipeline/translator.go
@@ -25,6 +25,10 @@ func Translator(lagQueue <-chan protocol.LagStatus, produceQueue chan<- string,
 	tsm := &utils.TwinStateMachine{}
 	tsm.Init()
 
+	// Prepare consumer side offset moves map
+	ownerPartitionOffsetMove := &utils.SyncNestedMap{}
+	ownerPartitionOffsetMove.Init()
+
 	for lag := range lagQueue {
 		// if lag doesn't change, sends it per 60s. Otherwise 30s.
 		shouldSendIt := tsm.Put(lag.Status.Cluster+lag.Status.Group, lag.Status.Totallag)

--- a/core/utils/syncMap.go
+++ b/core/utils/syncMap.go
@@ -7,7 +7,7 @@ import "sync"
 // and two threads would write.
 type SyncNestedMap struct {
 	sync.Mutex
-	infoMap     map[string]map[string]bool
+	infoMap     map[string]map[string]interface{}
 	clusterLock map[string]*sync.Mutex
 }
 
@@ -15,7 +15,7 @@ func (snm *SyncNestedMap) Init() {
 	snm.Lock()
 	defer snm.Unlock()
 
-	snm.infoMap = make(map[string]map[string]bool)
+	snm.infoMap = make(map[string]map[string]interface{})
 	snm.clusterLock = make(map[string]*sync.Mutex)
 }
 
@@ -43,13 +43,13 @@ func (snm *SyncNestedMap) ReleaseLock(cluster string) bool {
 	return true
 }
 
-func (snm *SyncNestedMap) GetChild(cluster string) map[string]bool {
+func (snm *SyncNestedMap) GetChild(cluster string) map[string]interface{} {
 	snm.Lock()
 	defer snm.Unlock()
 	if _, ok := snm.infoMap[cluster]; ok {
 
 	} else {
-		snm.infoMap[cluster] = make(map[string]bool)
+		snm.infoMap[cluster] = make(map[string]interface{})
 		snm.clusterLock[cluster] = &sync.Mutex{}
 	}
 	return snm.infoMap[cluster]

--- a/core/utils/syncMap.go
+++ b/core/utils/syncMap.go
@@ -2,64 +2,66 @@ package utils
 
 import "sync"
 
-// SyncNestedMap is used for goRainbow cluster-info mapping
+// SyncNestedMap is used for goRainbow parent-info mapping
 // No need to use RWMutex, because only main thread would read
 // and two threads would write.
 type SyncNestedMap struct {
 	sync.Mutex
-	infoMap     map[string]map[string]interface{}
-	clusterLock map[string]*sync.Mutex
+	infoMap    map[string]interface{}
+	parentLock map[string]*sync.Mutex
 }
 
 func (snm *SyncNestedMap) Init() {
 	snm.Lock()
 	defer snm.Unlock()
 
-	snm.infoMap = make(map[string]map[string]interface{})
-	snm.clusterLock = make(map[string]*sync.Mutex)
+	snm.infoMap = make(map[string]interface{})
+	snm.parentLock = make(map[string]*sync.Mutex)
 }
 
-// SetLock to set a refined lock, on cluster-level,
+// SetLock to set a refined lock, on parent-level,
 // to avoid blocking, to improve performance
-func (snm *SyncNestedMap) SetLock(cluster string) bool {
+func (snm *SyncNestedMap) SetLock(parent string) bool {
 	snm.Lock()
 	defer snm.Unlock()
 
-	if _, ok := snm.infoMap[cluster]; !ok {
+	if _, ok := snm.infoMap[parent]; !ok {
 		return false
 	}
-	snm.clusterLock[cluster].Lock()
+	snm.parentLock[parent].Lock()
 	return true
 }
 
-func (snm *SyncNestedMap) ReleaseLock(cluster string) bool {
+func (snm *SyncNestedMap) ReleaseLock(parent string) bool {
 	snm.Lock()
 	defer snm.Unlock()
 
-	if _, ok := snm.infoMap[cluster]; !ok {
+	if _, ok := snm.infoMap[parent]; !ok {
 		return false
 	}
-	snm.clusterLock[cluster].Unlock()
+	snm.parentLock[parent].Unlock()
 	return true
 }
 
-func (snm *SyncNestedMap) GetChild(cluster string) map[string]interface{} {
+func (snm *SyncNestedMap) GetChild(parent string, child interface{}) interface{} {
+
 	snm.Lock()
 	defer snm.Unlock()
-	if _, ok := snm.infoMap[cluster]; ok {
+	if _, ok := snm.infoMap[parent]; ok {
 
 	} else {
-		snm.infoMap[cluster] = make(map[string]interface{})
-		snm.clusterLock[cluster] = &sync.Mutex{}
+		snm.infoMap[parent] = child
+		snm.parentLock[parent] = &sync.Mutex{}
 	}
-	return snm.infoMap[cluster]
+	return snm.infoMap[parent]
 }
 
-func (snm *SyncNestedMap) DeregisterChild(cluster string, consumer string) {
-	// Refined cluster-level lock.
-	snm.SetLock(cluster)
-	defer snm.ReleaseLock(cluster)
+// I cannot enable this method now due to data type conflict, I will dive into it.
+// func (snm *SyncNestedMap) DeregisterChild(parent string, consumer string) {
+// 	// Refined parent-level lock.
+// 	snm.SetLock(parent)
+// 	defer snm.ReleaseLock(parent)
 
-	// May need to add a judge
-	delete(snm.infoMap[cluster], consumer)
-}
+// 	// May need to add a judge
+// 	delete(snm.infoMap[parent].(map[string]interface{}), consumer)
+// }

--- a/core/utils/syncMap_test.go
+++ b/core/utils/syncMap_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	Subject string
+}
+
+func TestBasic(t *testing.T) {
+	SyncNestedMap := &SyncNestedMap{}
+	SyncNestedMap.Init()
+
+	child := SyncNestedMap.GetChild("parent", make(map[string]bool)).(map[string]bool)
+	fmt.Println(child)
+
+	child["ok"] = true
+
+	expected := child["ok"]
+
+	child2 := SyncNestedMap.GetChild("parent", make(map[string]bool)).(map[string]bool)
+
+	assert.Equal(t, expected, child2["ok"], "not passed")
+
+	SyncNestedMap.SetLock("parent")
+	delete(child, "ok")
+	SyncNestedMap.ReleaseLock("parent")
+
+	child2 = SyncNestedMap.GetChild("parent", make(map[string]bool)).(map[string]bool)
+
+	assert.Equal(t, 0, len(child2), "not passed")
+}
+
+func TestStruct(t *testing.T) {
+	SyncNestedMap := &SyncNestedMap{}
+	SyncNestedMap.Init()
+
+	child := SyncNestedMap.GetChild("parent", make(map[string]testStruct)).(map[string]testStruct)
+	fmt.Println(child)
+
+	child["ok"] = testStruct{Subject: "hi"}
+
+	expected := child["ok"]
+
+	child2 := SyncNestedMap.GetChild("parent", make(map[string]testStruct)).(map[string]testStruct)
+
+	assert.Equal(t, expected, child2["ok"], "not passed")
+
+	SyncNestedMap.SetLock("parent")
+	delete(child, "ok")
+	SyncNestedMap.ReleaseLock("parent")
+
+	child2 = SyncNestedMap.GetChild("parent", make(map[string]testStruct)).(map[string]testStruct)
+
+	assert.Equal(t, 0, len(child2), "not passed")
+}


### PR DESCRIPTION
We want syncMap to support a new feature: consuming offset moves per host per minute. So generalized syncMap can have a better flexible.
Before, the syncMap is for maintaining alive topics and consumers.