### PR TITLE
Refactor: move timestamp to HTTP.GET exactly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 rainbow_log
 ./pipeline/rainbow_log
+profile.cov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Gitter](https://badges.gitter.im/BurrowRainbow/community.svg)](https://gitter.im/BurrowRainbow/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Build Status](https://travis-ci.org/HarbinZhang/goRainbow.svg)](https://travis-ci.org/HarbinZhang/goRainbow)
+[![Go Report Card](https://goreportcard.com/badge/github.com/HarbinZhang/goRainbow)](https://goreportcard.com/report/github.com/HarbinZhang/goRainbow)
 [![Coverage Status](https://coveralls.io/repos/github/HarbinZhang/goRainbow/badge.svg?branch=dev-coverage)](https://coveralls.io/github/HarbinZhang/goRainbow?branch=dev-coverage)
 
 

--- a/core/pipeline/consumerHandler.go
+++ b/core/pipeline/consumerHandler.go
@@ -41,14 +41,14 @@ func (ch *ConsumerHandler) Start() {
 
 	fmt.Println("New consumer found: ", ch.consumersLink, ch.consumer)
 
-	lagStatusQueue := make(chan protocol.LagStatus)
+	lagInfoQueue := make(chan protocol.LagInfo)
 
 	ticker := time.NewTicker(30 * time.Second)
 
 	prefix := "fjord.burrow." + ch.cluster + "." + ch.consumer
 
 	translator := &Translator{
-		LagQueue:     lagStatusQueue,
+		LagQueue:     lagInfoQueue,
 		ProduceQueue: ch.ProduceQueue,
 		CountService: ch.CountService,
 		Logger: util.GetLogger().With(
@@ -61,16 +61,17 @@ func (ch *ConsumerHandler) Start() {
 	for {
 		// check its ch.consumer lag from Burrow periodically
 		<-ticker.C
-		var lagStatus protocol.LagStatus
-		getHTTPStruct(ch.consumersLink+ch.consumer+"/lag", &lagStatus)
-		if lagStatus.Error {
+		var lagInfo protocol.LagInfo
+		getHTTPStruct(ch.consumersLink+ch.consumer+"/lag", &lagInfo.Lag)
+		if lagInfo.Lag.Error {
 			ch.Logger.Warn("Get consumer /lag error",
-				zap.String("message", lagStatus.Message),
+				zap.String("message", lagInfo.Lag.Message),
 				zap.Int64("timestamp", time.Now().Unix()),
 			)
 			break
 		}
-		lagStatusQueue <- lagStatus
+		lagInfo.Timestamp = time.Now().Unix()
+		lagInfoQueue <- lagInfo
 	}
 
 	// snm.DeregisterChild(cluster, ch.consumer)
@@ -78,7 +79,7 @@ func (ch *ConsumerHandler) Start() {
 	delete(ch.ClusterConsumerMap.GetChild(ch.cluster, nil).(map[string]interface{}), ch.consumer)
 	ch.ClusterConsumerMap.ReleaseLock(ch.cluster)
 
-	close(lagStatusQueue)
+	close(lagInfoQueue)
 	ch.Logger.Warn("consumer is invalid, will stop handler.",
 		zap.String("consumer", ch.consumer),
 		zap.String("cluster", ch.cluster),

--- a/core/pipeline/consumerHandler.go
+++ b/core/pipeline/consumerHandler.go
@@ -40,7 +40,6 @@ func (ch *ConsumerHandler) Start() {
 	defer ch.Logger.Sync()
 
 	fmt.Println("New consumer found: ", ch.consumersLink, ch.consumer)
-	var lagStatus protocol.LagStatus
 
 	lagStatusQueue := make(chan protocol.LagStatus)
 
@@ -62,6 +61,7 @@ func (ch *ConsumerHandler) Start() {
 	for {
 		// check its ch.consumer lag from Burrow periodically
 		<-ticker.C
+		var lagStatus protocol.LagStatus
 		getHTTPStruct(ch.consumersLink+ch.consumer+"/lag", &lagStatus)
 		if lagStatus.Error {
 			ch.Logger.Warn("Get consumer /lag error",
@@ -70,7 +70,6 @@ func (ch *ConsumerHandler) Start() {
 			)
 			break
 		}
-		// fmt.Println(lagStatus)
 		lagStatusQueue <- lagStatus
 	}
 

--- a/core/pipeline/topicHandler.go
+++ b/core/pipeline/topicHandler.go
@@ -66,7 +66,7 @@ func (th *TopicHandler) Start() {
 			break
 		}
 
-		go th.handleTopicOffset(topicOffset, prefix)
+		go th.handleTopicOffset(topicOffset, prefix, time.Now().Unix())
 
 	}
 
@@ -88,12 +88,12 @@ func (th *TopicHandler) Stop() error {
 	return nil
 }
 
-func (th *TopicHandler) handleTopicOffset(topicOffset protocol.TopicOffset, prefix string) {
+func (th *TopicHandler) handleTopicOffset(topicOffset protocol.TopicOffset, prefix string, timestamp int64) {
 	topicTag := "topic=" + th.topic
 	for id, offset := range topicOffset.Offsets {
-		timeString := strconv.FormatInt(time.Now().Unix(), 10)
+		timeString := strconv.FormatInt(timestamp, 10)
 		partitionIDTag := "partitionId=" + strconv.Itoa(id)
-		th.oom.Update(th.topic+":"+strconv.Itoa(id), offset, time.Now().Unix())
+		th.oom.Update(th.topic+":"+strconv.Itoa(id), offset, timestamp)
 		th.ProduceQueue <- combineInfo([]string{prefix, strconv.Itoa(id), "offset"},
 			[]string{strconv.Itoa(offset), timeString, th.postfix, topicTag, partitionIDTag})
 	}

--- a/core/pipeline/topicHandler.go
+++ b/core/pipeline/topicHandler.go
@@ -39,7 +39,6 @@ func (th *TopicHandler) Start() {
 	defer th.Logger.Sync()
 
 	fmt.Println("New topic found: ", th.topicLink, th.topic)
-	var topicOffset protocol.TopicOffset
 
 	prefix := "fjord.burrow." + th.cluster + ".topic." + th.topic
 
@@ -57,6 +56,7 @@ func (th *TopicHandler) Start() {
 	for {
 		// check its topic offset from Burrow periodically
 		<-ticker.C
+		var topicOffset protocol.TopicOffset
 		getHTTPStruct(th.topicLink+th.topic, &topicOffset)
 		if topicOffset.Error {
 			th.Logger.Warn("Get consumer /lag error",

--- a/core/pipeline/translator.go
+++ b/core/pipeline/translator.go
@@ -169,10 +169,6 @@ func (t *Translator) parseMaxLagInfo(maxLag protocol.MaxLag, postfix string) {
 	}
 }
 
-func getEpochTime() string {
-	return strconv.FormatInt(time.Now().Unix(), 10)
-}
-
 func combineInfo(prefix []string, postfix []string) string {
 	return strings.Join(prefix, ".") + " " + strings.Join(postfix, " ")
 }

--- a/core/protocol/lag.go
+++ b/core/protocol/lag.go
@@ -76,6 +76,7 @@ type LagStatus struct {
 	} `json:"request"`
 }
 
+// LagInfo is a customized struct to add an accurate timestamp
 type LagInfo struct {
 	Lag       LagStatus `json:"lag"`
 	Timestamp int64     `json:"timestamp"`

--- a/core/protocol/lag.go
+++ b/core/protocol/lag.go
@@ -76,6 +76,11 @@ type LagStatus struct {
 	} `json:"request"`
 }
 
+type LagInfo struct {
+	Lag       LagStatus `json:"lag"`
+	Timestamp int64     `json:"timestamp"`
+}
+
 // TopicOffset is for topic/offset
 type TopicOffset struct {
 	Error   bool   `json:"error"`

--- a/profile.cov
+++ b/profile.cov
@@ -1,0 +1,1 @@
+mode: count

--- a/profile.cov
+++ b/profile.cov
@@ -1,1 +1,0 @@
-mode: count

--- a/testAndCover.sh
+++ b/testAndCover.sh
@@ -9,7 +9,7 @@ function die() {
 }
 
 export GOPATH=`pwd`:$GOPATH
-
+echo $GOPATH
 # Initialize profile.cov
 echo "mode: count" > profile.cov
 
@@ -18,12 +18,12 @@ ERROR=""
 
 # Get package list
 PACKAGES=$(find core -type d -not -path '*/\.*')
-
+echo $PACKAGES
 # Test each package and append coverage profile info to profile.cov
 # Note this is just for coverage. We run the race detector separately because it won't work with count
 for pkg in $PACKAGES
 do
-    go test --timeout 5s -covermode=count -coverprofile=profile_tmp.cov github.com/HarbinZhang/goRainbow/$pkg || ERROR="Error testing $pkg"
+    go test --timeout 5s -covermode=count -coverprofile=profile_tmp.cov $pkg || ERROR="Error testing $pkg"
     if [ -f profile_tmp.cov ]
     then
         tail -n +2 profile_tmp.cov >> profile.cov || die "Unable to append coverage for $pkg"

--- a/testAndCover.sh
+++ b/testAndCover.sh
@@ -23,7 +23,7 @@ echo $PACKAGES
 # Note this is just for coverage. We run the race detector separately because it won't work with count
 for pkg in $PACKAGES
 do
-    go test --timeout 5s -covermode=count -coverprofile=profile_tmp.cov $pkg || ERROR="Error testing $pkg"
+    go test --timeout 5s -covermode=count -coverprofile=profile_tmp.cov github.com/HarbinZhang/goRainbow/$pkg || ERROR="Error testing $pkg"
     if [ -f profile_tmp.cov ]
     then
         tail -n +2 profile_tmp.cov >> profile.cov || die "Unable to append coverage for $pkg"


### PR DESCRIPTION
This code change
1. moves `timestamp=time.Now().Unix()` from translator to HTTP.GET request, so that we have an accurate timestamp of each lag pull. 
2. makes lag a local variable, which should fix a code bug.